### PR TITLE
Make module usable from command line

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -22,6 +22,9 @@ pydantic = [
     'typing_extensions>=4.12; python_version<="3.9"',
 ]
 
+[project.scripts]
+"techcable.orderedset" = "techcable.orderedset.__main__:_main"
+
 [dependency-groups]
 mypy = ["mypy~=1.0", {include-group = "typing"}]
 test = [

--- a/src/techcable/orderedset/__main__.py
+++ b/src/techcable/orderedset/__main__.py
@@ -14,9 +14,24 @@ from __future__ import annotations
 
 import argparse
 import sys
-from typing import IO, TypeVar
+from typing import IO, TypeVar, no_type_check
 
 from . import OrderedSet
+
+
+def _disable_traceback(disabled_type: type[BaseException], /) -> None:
+    """Disable traceback printing for a specific exception type"""
+    orig_excepthook = sys.excepthook
+
+    @no_type_check
+    def _filter_excepthook(type, value, traceback):
+        if issubclass(type, disabled_type):
+            pass  # do not print
+        else:
+            orig_excepthook(type, value, traceback)
+
+    sys.excepthook = _filter_excepthook
+
 
 S = TypeVar("S", str, bytes)
 
@@ -33,6 +48,7 @@ def _dedup_stream(input_file: IO[S], output_file: IO[S], /) -> None:
 
 
 def _main(raw_args: list[str] | None = None, /) -> None:
+    _disable_traceback(KeyboardInterrupt)
     parser = argparse.ArgumentParser(
         prog="techcable.orderedset", description="Print unique lines, preserving order"
     )

--- a/src/techcable/orderedset/__main__.py
+++ b/src/techcable/orderedset/__main__.py
@@ -1,0 +1,54 @@
+"""Print unique lines, preserving order.
+
+This is intended as a order-preserving alternative to `sort | uniq`,
+and a demonstration of techcable.OrderedSet functionality.
+Unlike `sort | uniq` it will immediately output lines as soon as they are received,
+without needing to wait for all input.
+
+It is only runnable as a python module (`python -m techcable.orderedset`)
+so it will not conflict with other commands or pollute your path.
+
+The functionality in this module is not intended for use as an API"""
+
+from __future__ import annotations
+
+import argparse
+import sys
+from typing import IO, TypeVar
+
+from . import OrderedSet
+
+S = TypeVar("S", str, bytes)
+
+
+def _dedup_stream(input_file: IO[S], output_file: IO[S], /) -> None:
+    assert input_file.readable()
+    assert output_file.writable()
+    oset: OrderedSet[S] = OrderedSet()
+    while line := input_file.readline():
+        # OrderedSet.append returns True if the item is newly added,
+        # and False if it already exists
+        if oset.append(line):
+            output_file.write(line)
+
+
+def _main(raw_args: list[str] | None = None, /) -> None:
+    parser = argparse.ArgumentParser(
+        prog="techcable.orderedset", description="Print unique lines, preserving order"
+    )
+    parser.add_argument(
+        "input_file",
+        type=argparse.FileType(mode="br"),
+        help="The input file to read from",
+        nargs="?",
+        default="-",
+    )
+
+    args = parser.parse_args(raw_args)
+    _dedup_stream(args.input_file, sys.stdout.buffer)
+
+
+if __name__ == "__main__":
+    _main()
+
+__all__ = ()


### PR DESCRIPTION
This is better than `uniq | sort`,
because it preserves order and does not wait for all the input.

Runs only as a module, to avoid polluting the path.

**TODO**: Needs better docs and mention in README.
